### PR TITLE
conversion.hpp: add missing #include <cstdint>

### DIFF
--- a/essentials/include/essentials/conversion.hpp
+++ b/essentials/include/essentials/conversion.hpp
@@ -7,6 +7,7 @@
 #define CONVERSION_99CAC61B_DD8A_43E2_8612_0F42873A5741
 
 
+#include <cstdint>
 #include <string>
 #include <sstream>
 #include <limits>


### PR DESCRIPTION
Fixes a compilation error when building with aarch64-linux-gnu-g++-14.